### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you are using OpenQuick WITHOUT Marmalade Quick, then the runtime OS
 abstraction you are using will be Cocos2d-x's - i.e. you are using the
 Cocos2d-x platform back-ends, such as proj.win32.
 
-##Working with GitHub vs Marmalade SDK
+## Working with GitHub vs Marmalade SDK
 
 OpenQuick is distributed as source both inside the Marmalade SDK (in
 modules/third_party/openquick) and on github (at


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
